### PR TITLE
Bump actions/* to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: mazoea/ga-maz/start@master
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: pull and build
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CI workflow for te_base_dep_3.9 branch and wait for result
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Update GitHub Actions to their current latest major releases:

- `actions/cache@v5`
- `actions/checkout@v6`
- `actions/download-artifact@v8`
- `actions/github-script@v9`
- `actions/setup-python@v6`
- `actions/stale@v10`
- `actions/upload-artifact@v7`

Only versions actually present in this repository's workflows are touched.

Note: newer majors of these actions ship with Node.js 24 runtime. Workflows that run inside legacy containers (Ubuntu 20 / older glibc) may need their container image bumped — watch CI.